### PR TITLE
Azurelinux support

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -107,6 +107,13 @@ pub fn set_environment(distro: &distro::Distro) {
             debug!("Subtype: {distrosubtype}");
             env::set_var("DISTROSUBTYPE", format!("{}", distrosubtype));
         }
+        dkind if dkind.distro_type == distro::DistroType::Debian => {
+            debug!("Type {} detected", dkind.distro_type);
+            env::set_var("isDebian", convert_bool(true));
+            let distrosubtype = dkind.distro_subtype;
+            debug!("Subtype: {distrosubtype}");
+            env::set_var("DISTROSUBTYPE", format!("{}", distrosubtype));
+        }
         _ => {
             env::set_var("DISTROTYPE", "UNKNOWN");
             env::set_var("DISTROSUBTYPE", "UNKNOWN");

--- a/src/action_implementation/initrd-impl.sh
+++ b/src/action_implementation/initrd-impl.sh
@@ -1,55 +1,55 @@
 #!/bin/bash
-# recover logic for handling and initrd or kernel problem
+# recover logic for handling initrd or kernel problem
 #
 
 recover_suse() {
-    # Kernel will be one of the following styles of files - vmlinux-5.14.21-150400.14.31-azure vmlinuz-4.12.14-6.43-azure vmlinuz-4.12.14-95.68-default
-    # initrd will similarly be - initrd-5.14.21-150400.14.31-azure, initrd-4.12.14-6.43-azure, initrd-4.12.14-95.68-default
-    # there should be a link from 'vmlinuz' and 'initrd' to one of those kernels and corresponding initrd.
-    # -- try to use the links above to find the kernel version, failing that logic, look for the last package installed
-    KERNFILE=$(basename $(realpath -e /boot/vmlinuz))
-    RET=$?
+	# Kernel will be one of the following styles of files - vmlinux-5.14.21-150400.14.31-azure vmlinuz-4.12.14-6.43-azure vmlinuz-4.12.14-95.68-default
+	# initrd will similarly be - initrd-5.14.21-150400.14.31-azure, initrd-4.12.14-6.43-azure, initrd-4.12.14-95.68-default
+	# there should be a link from 'vmlinuz' and 'initrd' to one of those kernels and corresponding initrd.
+	# -- try to use the links above to find the kernel version, failing that logic, look for the last package installed
+	KERNFILE=$(basename $(realpath -e /boot/vmlinuz))
+	RET=$?
 
-    # Set these vars up first, for var scope. if $KERNFILE is garbage we'll fix them in the if|fi block below
-    KERNVER=$(echo "${KERNFILE%-*}" | sed 's/vmlinuz-//')
-    KERNBASE=$(echo "${KERNFILE##*-}")
+	# Set these vars up first, for var scope. if $KERNFILE is garbage we'll fix them in the if|fi block below
+	KERNVER=$(echo "${KERNFILE%-*}" | sed 's/vmlinuz-//')
+	KERNBASE=$(echo "${KERNFILE##*-}")
 
-    if [[ $RET != 0 ]]; then
-        # We probably didn't have a link for some reason, so fall back to using the package name
-        KERNNAME=$(rpm -qa name="kernel-*" --last | head -n 1 | cut -f 1 -d " " | sed 's/kernel-//' | sed 's/.1.x86_64//')
-        KERNVER=$(echo $KERNNAME | cut -d '-' -f 2-)
-        KERNBASE=$(echo $KERNNAME | cut -d '-' -f 1)
-        KERNFILE=vmlinuz-$KERNVER-$KERNBASE
-    fi
-    
-    INITRD=$(echo $KERNFILE | sed 's/vmlinuz/initrd/')
-    # Get sure that all required modules are loaded
-    dracut -f -v  --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/$INITRD ${KERNVER}-$KERNBASE
-    # recreate the initrd link  (do this in pwd instead of a absolute path link)
-    ln -s /boot/$INITRD /boot/initrd
-    grub2-mkconfig -o /boot/grub2/grub.cfg
+	if [[ $RET != 0 ]]; then
+		# We probably didn't have a link for some reason, so fall back to using the package name
+		KERNNAME=$(rpm -qa name="kernel-*" --last | head -n 1 | cut -f 1 -d " " | sed 's/kernel-//' | sed 's/.1.x86_64//')
+		KERNVER=$(echo $KERNNAME | cut -d '-' -f 2-)
+		KERNBASE=$(echo $KERNNAME | cut -d '-' -f 1)
+		KERNFILE=vmlinuz-$KERNVER-$KERNBASE
+	fi
+
+	INITRD=$(echo $KERNFILE | sed 's/vmlinuz/initrd/')
+	# Get sure that all required modules are loaded
+	dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/$INITRD ${KERNVER}-$KERNBASE
+	# recreate the initrd link  (do this in pwd instead of a absolute path link)
+	ln -s /boot/$INITRD /boot/initrd
+	grub2-mkconfig -o /boot/grub2/grub.cfg
 }
 
 recover_ubuntu() {
-    if [[ ! -e /var/log/dpkg.log ]]; then
-    # if this file is empty we have to assume that we have a vanilla system. Only one kernel available
-        kernel_version=$(ls /boot/vmlinuz-*)
-        kernel_version=${kernel_version#/boot/vmlinuz-}
-    else
-        kernel_version=$( zgrep linux-image /var/log/dpkg.log* | grep installed  | cut -d' ' -f5 | cut -d':' -f1 | sed -e 's/linux-image-//' | grep ^[1-9] | sort -V | tail -n 1)
-    fi
-    # This is needed on Debian only
-    if [[ -e /boot/initrd.img-${kernel_version} ]]; then
-            rm /boot/initrd.img-${kernel_version}
-    fi
-    # Get sure that all required modles are loaded
-        echo "hv_vmbus" >> /etc/initramfs-tools/modules
-        echo "hv_storvsc" >> /etc/initramfs-tools/modules
-        echo "hv_netvsc" >> /etc/initramfs-tools/modules
+	if [[ ! -e /var/log/dpkg.log ]]; then
+		# if this file is empty we have to assume that we have a vanilla system. Only one kernel available
+		kernel_version=$(ls /boot/vmlinuz-*)
+		kernel_version=${kernel_version#/boot/vmlinuz-}
+	else
+		kernel_version=$(zgrep linux-image /var/log/dpkg.log* | grep installed | cut -d' ' -f5 | cut -d':' -f1 | sed -e 's/linux-image-//' | grep ^[1-9] | sort -V | tail -n 1)
+	fi
+	# This is needed on Debian only
+	if [[ -e /boot/initrd.img-${kernel_version} ]]; then
+		rm /boot/initrd.img-${kernel_version}
+	fi
+	# Get sure that all required modles are loaded
+	echo "hv_vmbus" >>/etc/initramfs-tools/modules
+	echo "hv_storvsc" >>/etc/initramfs-tools/modules
+	echo "hv_netvsc" >>/etc/initramfs-tools/modules
 
-    update-initramfs -k "$kernel_version" -c
-    grub-mkconfig -o /boot/grub/grub.cfg
-    grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
+	update-initramfs -k "$kernel_version" -c
+	grub-mkconfig -o /boot/grub/grub.cfg
+	grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
 
 }
 
@@ -57,34 +57,59 @@ recover_ubuntu() {
 # Should handle all redhat based distros
 #
 recover_redhat() {
-    kernel_version=$(sed -e "s/kernel-//" <<< $(rpm -q kernel --last  | head -n 1 | cut -f1 -d' '))
-    if [[ "$isRedHat6" == "true" ]]; then
-        # verify the grub.conf and correct it if needed
-        cd "$tmp_dir"
-        awk -f alar-fki/grub.awk /boot/grub/grub.conf
-        # rebuild the initrd
-        dracut -f /boot/initramfs-"${kernel_version}".img "$kernel_version"
-    else
-        depmod ${kernel_version}
-        # Get sure that all required modules are loaded
-        dracut -f -v  --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initramfs-${kernel_version}.img ${kernel_version}
-        # Recreate the the grub.cfg, it could be the initrd line is missing
-        grub2-mkconfig -o /boot/grub2/grub.cfg
-        #grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
-    fi
+	kernel_version=$(sed -e "s/kernel-//" <<<$(rpm -q kernel --last | head -n 1 | cut -f1 -d' '))
+
+	if [[ "$isAzureLinux" == "true" ]]; then
+		# On AzureLinux we need to remove the architecture part
+		kernel_version="${kernel_version//.x86_64/}"
+	fi
+
+	depmod ${kernel_version}
+	# Get sure that all required modules are loaded
+	dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initramfs-${kernel_version}.img ${kernel_version}
+	# Recreate the the grub.cfg, it could be the initrd line is missing
+	grub2-mkconfig -o /boot/grub2/grub.cfg
 
 }
 
+recover_azurelinux() {
+	kernel_version=$(sed -e "s/kernel-//" <<<$(rpm -q kernel --last | head -n 1 | cut -f1 -d' '))
+
+	# On AzureLinux we need to remove the architecture part
+	kernel_version="${kernel_version//.x86_64/}"
+	kernel_version="${kernel_version//.aarch64/}"
+
+	depmod ${kernel_version}
+	# Get sure that all required modules are loaded
+	if test initrd.img*; then 
+		# AzureLinux 2.0
+		dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initrd.img-${kernel_version} ${kernel_version}
+	else
+		# AzureLinux 3.0
+		dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initramfs-${kernel_version}.img ${kernel_version}
+	fi
+	# Recreate the the grub.cfg, it could be the initrd line is missing
+	grub2-mkconfig -o /boot/grub2/grub.cfg
+}
+
 if [[ "$isRedHat" == "true" ]]; then
-    recover_redhat
+	recover_redhat
 fi
 
 if [[ "$isSuse" == "true" ]]; then
-    recover_suse
+	recover_suse
 fi
 
 if [[ "$isUbuntu" == "true" ]]; then
-    recover_ubuntu
+	recover_ubuntu
+fi
+
+if [[ "$isDebian" == "true" ]]; then
+	recover_ubuntu
+fi
+
+if [[ "$isAzureLinux" == "true" ]]; then
+	recover_azurelinux
 fi
 
 exit 0

--- a/src/action_implementation/initrd-impl.sh
+++ b/src/action_implementation/initrd-impl.sh
@@ -59,11 +59,6 @@ recover_ubuntu() {
 recover_redhat() {
 	kernel_version=$(sed -e "s/kernel-//" <<<$(rpm -q kernel --last | head -n 1 | cut -f1 -d' '))
 
-	if [[ "$isAzureLinux" == "true" ]]; then
-		# On AzureLinux we need to remove the architecture part
-		kernel_version="${kernel_version//.x86_64/}"
-	fi
-
 	depmod ${kernel_version}
 	# Get sure that all required modules are loaded
 	dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initramfs-${kernel_version}.img ${kernel_version}
@@ -81,7 +76,7 @@ recover_azurelinux() {
 
 	depmod ${kernel_version}
 	# Get sure that all required modules are loaded
-	if test initrd.img*; then 
+	if test initrd.img*; then
 		# AzureLinux 2.0
 		dracut -f -v --add-drivers "hv_vmbus hv_netvsc hv_storvsc" /boot/initrd.img-${kernel_version} ${kernel_version}
 	else

--- a/src/action_implementation/kernel-impl.sh
+++ b/src/action_implementation/kernel-impl.sh
@@ -22,7 +22,7 @@ if [[ ${isRedHat} == "true" ]]; then
 	echo "kernel.sysrq = 1" >>/etc/sysctl.conf
 fi
 
-if [[ ${isUbuntu} == "true" ]]; then
+if [[ ${isUbuntu} == "true" || ${isDebian}  == "true" ]]; then
 	# verify whether GRUB_DEFAULT is available
 	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
 

--- a/src/action_implementation/kernel-impl.sh
+++ b/src/action_implementation/kernel-impl.sh
@@ -1,50 +1,52 @@
 #!/bin/bash
 # The main intention is to roll back to the previous working kernel
 # We do this by altering the grub configuration
-
-# From the man page
-# Set the default boot menu entry for GRUB.  This requires setting GRUB_DEFAULT=saved in /etc/default/grub
-set_grub_default() {
-        # verify whether GRUB_DEFAULT is available
-        grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
-        # The next line could be garded and/or improved with the help of an if for instance
-        # though I keep it simple
-        sed -i "s/GRUB_DEFAULT=[[:digit:]]/GRUB_DEFAULT=saved/" /etc/default/grub
-}
-
-# set the default kernel accordingly
-# This is different for RedHat and Ubuntu/SUSE distros
+# This is different for RedHat based distros and Ubuntu/SUSE distros
 # Ubuntu and SLES use sub-menues
 # Variables are set by action.rs
 
-if [[ $isRedHat == "true" ]]; then
-        if [[ $isRedHat6 == "true" ]]; then
-                grubby --set-default=1 # This is the previous kernel
-                ldconfig
-        else
-                set_grub_default
-                # set to previous kernel
-                sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=1/' /etc/default/grub
+if [[ ${isRedHat} == "true" ]]; then
+	# verify whether GRUB_DEFAULT is available
+	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
 
-                # Generate both config files. 
-                grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
-                grub2-mkconfig -o /boot/grub2/grub.cfg
+	# set to previous kernel
+	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=1/' /etc/default/grub
 
-                # enable sysreq
-                echo "kernel.sysrq = 1" >>/etc/sysctl.conf
-        fi
+	# Generate both config files.
+	# TODO - check if we need to generate both. Newer distro version don't require this anymore. Let us create a backup therefore.
+	cp /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg.bak
+	grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+	grub2-mkconfig -o /boot/grub2/grub.cfg
+
+	# enable sysreq
+	echo "kernel.sysrq = 1" >>/etc/sysctl.conf
 fi
 
-if [[ $isUbuntu == "true" ]]; then
-        set_grub_default
-        sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="1>2"/' /etc/default/grub
-        update-grub
+if [[ ${isUbuntu} == "true" ]]; then
+	# verify whether GRUB_DEFAULT is available
+	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
+
+	# set to previous kernel
+	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="1>2"/' /etc/default/grub
+	update-grub
 fi
 
-if [[ $isSuse == "true" ]]; then
-        set_grub_default
-        sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="1>2"/' /etc/default/grub
-        grub2-mkconfig -o /boot/grub2/grub.cfg
+if [[ ${isSuse} == "true" ]]; then
+	# verify whether GRUB_DEFAULT is available
+	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
+ 
+	# set to previous kernel
+	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="1>2"/' /etc/default/grub
+	grub2-mkconfig -o /boot/grub2/grub.cfg
+fi
+
+if [[ ${isAzureLinux} == "true" ]]; then
+	# verify whether GRUB_DEFAULT is available
+	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
+	
+        # set to previous kernel
+	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=2/' /etc/default/grub
+	grub2-mkconfig -o /boot/grub2/grub.cfg
 fi
 
 # For reference --> https://www.linuxsecrets.com/2815-grub2-submenu-change-boot-order

--- a/src/action_implementation/kernel-impl.sh
+++ b/src/action_implementation/kernel-impl.sh
@@ -34,7 +34,7 @@ fi
 if [[ ${isSuse} == "true" ]]; then
 	# verify whether GRUB_DEFAULT is available
 	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
- 
+
 	# set to previous kernel
 	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="1>2"/' /etc/default/grub
 	grub2-mkconfig -o /boot/grub2/grub.cfg
@@ -43,8 +43,8 @@ fi
 if [[ ${isAzureLinux} == "true" ]]; then
 	# verify whether GRUB_DEFAULT is available
 	grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
-	
-        # set to previous kernel
+
+	# set to previous kernel
 	sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=2/' /etc/default/grub
 	grub2-mkconfig -o /boot/grub2/grub.cfg
 fi

--- a/src/action_implementation/serialconsole-impl.sh
+++ b/src/action_implementation/serialconsole-impl.sh
@@ -29,7 +29,7 @@ alter_serial_properties() {
 }
 
 serial_fix_suse_redhat () {
-    if [[ "$isRedHat6" == "true" ]]; then
+    if [[ ${DISTROVERSION} =~ 6 ]]; then 
         echo "Configuring the serialconsole for RedHat 6.x is not implemented"
         exit 1
     fi


### PR DESCRIPTION
Added missing distro Debian. Which is required for action scrips.
Extended initrd and kernelto support Debian.
Added support for AzureLinux; Removed functionality which was required for RedHat 6; RedHat 6 isn't supported anymore;
Also added created a new cp operation to save the EFI grub.cfg.