### PR TITLE
Disable os-prober on grub2-mkconfig for RHEL

### DIFF
--- a/src/action_implementation/efifix-impl.sh
+++ b/src/action_implementation/efifix-impl.sh
@@ -26,8 +26,8 @@ recover_redhat() {
     yum reinstall -y grub2-efi-x64 shim-x64
     yum reinstall grub2-common -y
     
-    grub2-mkconfig -o /boot/grub2/grub.cfg
-    grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+    GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/grub2/grub.cfg
+    GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
     uuid_to_be_replaced=$(awk '/efi/ {print($1)}' /etc/fstab)
     new_efi_uuid=$(blkid -s UUID -o value $(findmnt /boot/efi -o SOURCE -n))
     sed -i "s/$uuid_to_be_replaced/UUID=$new_efi_uuid/" /etc/fstab

--- a/src/action_implementation/grubfix-impl.sh
+++ b/src/action_implementation/grubfix-impl.sh
@@ -27,7 +27,7 @@ recover_redhat() {
         exit 1
     fi
     # We fixed the clasic boot loader, no need to fix the EFI boot loader part.
-    grub2-mkconfig -o /boot/grub2/grub.cfg
+    GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/grub2/grub.cfg
 
     resolv-after
 }

--- a/src/action_implementation/kernel-impl.sh
+++ b/src/action_implementation/kernel-impl.sh
@@ -15,8 +15,8 @@ if [[ ${isRedHat} == "true" ]]; then
 	# Generate both config files.
 	# TODO - check if we need to generate both. Newer distro version don't require this anymore. Let us create a backup therefore.
 	cp /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg.bak
-	grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
-	grub2-mkconfig -o /boot/grub2/grub.cfg
+	GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+	GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/grub2/grub.cfg
 
 	# enable sysreq
 	echo "kernel.sysrq = 1" >>/etc/sysctl.conf


### PR DESCRIPTION
For modern RHEL the os-prober can be ignore. This will be important so it will not try to add the entry on grub from the OS disk from the rescue VM. You could end with a Red Hat grub showing an entry for Ubuntu
<img width="1261" height="597" alt="image" src="https://github.com/user-attachments/assets/3147fd44-7b52-4ac4-8f12-68c09bfc2701" />
